### PR TITLE
ci: test GHC 9.4.8 through 9.14.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.5", "9.8.2"]
+        ghc: ["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]
         os:
           - ubuntu-latest
           - windows-latest

--- a/hw-prelude.cabal
+++ b/hw-prelude.cabal
@@ -9,6 +9,7 @@ author:                 John Ky
 maintainer:             newhoggy@gmail.com
 copyright:              2024 John Ky
 category:               Development
+tested-with:            GHC == 9.14.1, GHC == 9.12.4, GHC == 9.10.3, GHC == 9.8.4, GHC == 9.6.7, GHC == 9.4.8
 build-type:             Simple
 extra-doc-files:        CHANGELOG.md
 extra-source-files:     README.md
@@ -25,7 +26,7 @@ common bytestring                 { build-depends: bytestring                   
 common contravariant              { build-depends: contravariant                               < 1.6    }
 common directory                  { build-depends: directory                                   < 1.4    }
 common filepath                   { build-depends: filepath                                    < 1.6    }
-common generic-lens               { build-depends: generic-lens                                < 2.3    }
+common generic-lens               { build-depends: generic-lens                                < 2.4    }
 common microlens                  { build-depends: microlens                                   < 0.5    }
 common network                    { build-depends: network                                     < 3.3    }
 common process                    { build-depends: process                                     < 1.7    }


### PR DESCRIPTION
Brings the tested GHC versions in line with hw-prim, to the extent supportable.

## GHC matrix
- CI matrix: `["9.6.5", "9.8.2"]` -> `["9.14.1", "9.12.4", "9.10.3", "9.8.4", "9.6.7", "9.4.8"]` (same as hw-prim)
- Added `tested-with: GHC == 9.14.1, GHC == 9.12.4, GHC == 9.10.3, GHC == 9.8.4, GHC == 9.6.7, GHC == 9.4.8` to the cabal file
- Unlike hw-prim, GHC 8.8.4/8.10.7/9.0.2 are omitted: the `NoFieldSelectors` and `OverloadedRecordDot` default extensions require GHC >= 9.2. GHC 9.2.8 is also left out of the matrix as it has never been tested here.

## Bound changes
- `generic-lens < 2.3` -> `< 2.4`: generic-lens 2.2.2.0 only supports up to GHC 9.8; 2.3.0.0 (used by Stackage nightly) supports GHC 9.10-9.14
- All other bounds already admit base 4.22 / GHC 9.14 (verified against Hackage metadata; aeson 2.2.5.0 is tested with GHC 9.14.1)

Verified locally: `cabal build --enable-tests` and `cabal check` pass with GHC 9.8.4.